### PR TITLE
Refactor ExportableCollection pluck return types and add itemToArray normalisation

### DIFF
--- a/src/Collections/ExportableCollection.php
+++ b/src/Collections/ExportableCollection.php
@@ -20,9 +20,7 @@ class ExportableCollection extends Collection
      *
      * @param  string|array  $value
      * @param  string|null  $key
-     *
      * @return \Illuminate\Support\Collection<(int|string), non-empty-array<string, mixed>>|\Illuminate\Support\Collection<(int|string), array>
-     *
      */
     public function pluck($value, $key = null): \Illuminate\Support\Collection
     {

--- a/src/Collections/ExportableCollection.php
+++ b/src/Collections/ExportableCollection.php
@@ -20,8 +20,11 @@ class ExportableCollection extends Collection
      *
      * @param  string|array  $value
      * @param  string|null  $key
+     *
+     * @return \Illuminate\Support\Collection<(int|string), non-empty-array<string, mixed>>|\Illuminate\Support\Collection<(int|string), array>
+     *
      */
-    public function pluck($value, $key = null): ExportableCollection|\Illuminate\Support\Collection
+    public function pluck($value, $key = null): \Illuminate\Support\Collection
     {
         if (is_string($value)) {
             return $this->map(function ($item) use ($value) {

--- a/src/Collections/ExportableCollection.php
+++ b/src/Collections/ExportableCollection.php
@@ -4,7 +4,6 @@ namespace PeterSowah\LaravelFactoryDumps\Collections;
 
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Collection as SupportCollection;
 use Illuminate\Support\Facades\File;
 use League\Csv\CannotInsertRecord;
 use League\Csv\Exception;
@@ -22,7 +21,7 @@ class ExportableCollection extends Collection
      * @param  string|array  $value
      * @param  string|null  $key
      */
-    public function pluck($value, $key = null): SupportCollection
+    public function pluck($value, $key = null): ExportableCollection|\Illuminate\Support\Collection
     {
         if (is_string($value)) {
             return $this->map(function ($item) use ($value) {

--- a/tests/ExportableFactoryTest.php
+++ b/tests/ExportableFactoryTest.php
@@ -4,6 +4,7 @@ namespace Tests;
 
 use Illuminate\Support\Facades\File;
 use Maatwebsite\Excel\ExcelServiceProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Workbench\App\Models\User;
 
 class ExportableFactoryTest extends TestCase
@@ -64,7 +65,7 @@ class ExportableFactoryTest extends TestCase
         ]);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_export_factory_data_to_csv_after_creation(): void
     {
         $users = User::factory()->count(10)->create();
@@ -74,7 +75,7 @@ class ExportableFactoryTest extends TestCase
         $this->assertStringContainsString('users.csv', $csvFile);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_export_factory_data_to_excel_after_creation(): void
     {
         $users = User::factory()->count(10)->create();
@@ -84,7 +85,7 @@ class ExportableFactoryTest extends TestCase
         $this->assertStringContainsString('users.xlsx', $excelFile);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_export_all_users_to_csv_using_static_method(): void
     {
         User::factory()->count(10)->create();
@@ -95,7 +96,7 @@ class ExportableFactoryTest extends TestCase
         $this->assertStringContainsString('users.csv', $csvFile);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_export_all_users_to_excel_using_static_method(): void
     {
         User::factory()->count(10)->create();
@@ -106,7 +107,7 @@ class ExportableFactoryTest extends TestCase
         $this->assertStringContainsString('users.xlsx', $excelFile);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_export_with_custom_filename(): void
     {
         User::factory()->count(10)->create();

--- a/tests/Unit/ExportableCollectionTest.php
+++ b/tests/Unit/ExportableCollectionTest.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\File;
 use Maatwebsite\Excel\Facades\Excel;
 use PeterSowah\LaravelFactoryDumps\Collections\ExportableCollection;
 use PeterSowah\LaravelFactoryDumps\Exports\ExportFactory;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class TestModel extends Model
@@ -53,6 +54,7 @@ class ExportableCollectionTest extends TestCase
         parent::tearDown();
     }
 
+    #[Test]
     public function it_can_pluck_specific_columns()
     {
         $collection = new ExportableCollection([
@@ -68,6 +70,7 @@ class ExportableCollectionTest extends TestCase
         ], $result->toArray());
     }
 
+    #[Test]
     public function it_can_pluck_a_single_column()
     {
         $collection = new ExportableCollection([
@@ -83,6 +86,7 @@ class ExportableCollectionTest extends TestCase
         ], $result->toArray());
     }
 
+    #[Test]
     public function it_can_pluck_with_custom_column_names()
     {
         $collection = new ExportableCollection([
@@ -102,6 +106,7 @@ class ExportableCollectionTest extends TestCase
         ], $result->toArray());
     }
 
+    #[Test]
     public function it_can_export_collection_to_csv_file()
     {
         $collection = new ExportableCollection([
@@ -120,6 +125,7 @@ class ExportableCollectionTest extends TestCase
         $this->assertStringContainsString('2,Jane,jane@example.com', $csvContent);
     }
 
+    #[Test]
     public function it_uses_model_table_name_when_no_filename_provided_for_csv()
     {
         $model = new TestModel(['name' => 'John', 'email' => 'john@example.com']);
@@ -130,6 +136,7 @@ class ExportableCollectionTest extends TestCase
         $this->assertEquals(database_path('dumps/csv/test_table.csv'), $filePath);
     }
 
+    #[Test]
     public function it_uses_export_as_default_name_for_array_data_in_csv()
     {
         $collection = new ExportableCollection([
@@ -141,6 +148,7 @@ class ExportableCollectionTest extends TestCase
         $this->assertEquals(database_path('dumps/csv/export.csv'), $filePath);
     }
 
+    #[Test]
     public function it_can_export_collection_to_excel_file()
     {
         $collection = new ExportableCollection([
@@ -162,6 +170,7 @@ class ExportableCollectionTest extends TestCase
         $this->assertEquals(config('factory-dumps.path').'/dumps/excel/test.xlsx', $filePath);
     }
 
+    #[Test]
     public function it_uses_model_table_name_when_no_filename_provided_for_excel()
     {
         $model = new TestModel(['name' => 'John', 'email' => 'john@example.com']);
@@ -181,6 +190,7 @@ class ExportableCollectionTest extends TestCase
         $this->assertEquals(config('factory-dumps.path').'/dumps/excel/test_table.xlsx', $filePath);
     }
 
+    #[Test]
     public function it_uses_export_as_default_name_for_array_data_in_excel()
     {
         $collection = new ExportableCollection([


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Pluck now returns a standard collection for better interoperability.
  * Export items are uniformly normalized, producing consistent headers and column ordering inferred from the first record.
  * Export filename inference improved and export flows unified for CSV/Excel.

* **Bug Fixes**
  * CSV/Excel export now errors clearly on empty collections.

* **Tests**
  * Test annotations migrated to PHP 8 attributes for modern test discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->